### PR TITLE
minor update julia and  pass build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,17 +14,18 @@ RUN  apt-get update && \
      apt-get install -y gfortran python && \
      apt-get install -y m4 cmake libssl-dev && \
      cd /usr/local/src && git clone https://github.com/JuliaLang/julia.git && \
-     cd julia && git checkout v0.6.0 && \
+     cd julia && git checkout v0.6.2 && \
      # Use generic instruction set; see https://github.com/JuliaLang/julia/pull/6220
      #   and https://groups.google.com/forum/#!topic/julia-dev/Eqp0GhZWxME
      echo "JULIA_CPU_TARGET=core2" > Make.user && \
+     echo "OPENBLAS_TARGET_ARCH=NEHALEM" > Make.user && \
      make -j 4 julia-deps && make -j 4 && make install && \
      ln -s /usr/local/src/julia/julia /usr/local/bin/julia
 
 ENV JULIA_PKGDIR /root/.julia/v0.6
 
 RUN julia /tmp/package_installs.jl
-    
+
 # IJulia
 RUN   apt-get update && apt-get install -y python3-pip python3-dev && pip3 install jupyter && \
         julia -e "Pkg.add(\"Nettle\")" && \


### PR DESCRIPTION
julia v0.6.0 -> v0.6.2

And, this Dockerfile occurs an error during `docker build`.

```
make[2]: *** [getarch_2nd] Error 1
Makefile:123: *** OpenBLAS: Detecting CPU failed. Please set TARGET explicitly, e.g. make TARGET=your_cpu_target. Please read README for the detail..  Stop.
*** Clean the OpenBLAS build with 'make -C deps clean-openblas'. Rebuild with 'make OPENBLAS_USE_THREAD=0' if OpenBLAS had trouble linking libpthread.so, and with 'make OPENBLAS_TARGET_ARCH=NEHALEM' if there were errors building SandyBridge support. Both these options can also be used simultaneously. ***
/usr/local/src/julia/deps/blas.mk:111: recipe for target 'scratch/openblas-85636ff1a015d04d3a8f960bc644b85ee5157135/build-compiled' failed
make[1]: *** [scratch/openblas-85636ff1a015d04d3a8f960bc644b85ee5157135/build-compiled] Error 1
```

So I fixed it. This Dockerfile passed `docker build`.

I tried `echo "TARGET=core2" > Make.user && \` too. But that failed build.